### PR TITLE
Accurate Character Orientation

### DIFF
--- a/Characters/Character.cs
+++ b/Characters/Character.cs
@@ -83,7 +83,8 @@ namespace Desktoptale.Characters
         private Subscription focusCharacterSubscription;
         private Subscription unfocusCharacterSubscription;
         private Subscription changeContainingWindowSubscription;
-        
+        private bool orientationLock;
+
         public Character(CharacterCreationContext characterCreationContext)
         {
             properties = characterCreationContext.Properties;
@@ -295,10 +296,25 @@ namespace Desktoptale.Characters
 
         private Orientation? GetOrientationFromVelocity(Vector2 input)
         {
-            if (input.Y < -float.Epsilon) return Orientation.Up;
-            if (input.Y > float.Epsilon) return Orientation.Down;
-            if (input.X < -float.Epsilon) return Orientation.Left;
-            if (input.X > float.Epsilon) return Orientation.Right;
+			if (!orientationLock)
+			{
+				if (input.Y < -float.Epsilon) return Orientation.Up; orientationLock = true;
+				if (input.Y > float.Epsilon) return Orientation.Down; orientationLock = true;
+				if (input.X < -float.Epsilon) return Orientation.Left; orientationLock = true;
+				if (input.X > float.Epsilon) return Orientation.Right; orientationLock = true;
+			}
+			else 
+			{
+				if (
+					(Orientation == Orientation.Up && input.Y >= -float.Epsilon) ||
+					(Orientation == Orientation.Down && input.Y <= float.Epsilon) ||
+					(Orientation == Orientation.Left && input.X >= -float.Epsilon) ||
+					(Orientation == Orientation.Right && input.X <= float.Epsilon)
+				)
+				{
+					orientationLock = false;
+				}
+			}
 
             return null;
         }


### PR DESCRIPTION
Currently, pressing up or down makes you face that direction immediately, no matter which direction you're already pressing.
This PR makes it more accurate to Undertale by letting you move diagonally while facing left or right

(i'm not a c# expert and this is probably not the best way to do it but it works)